### PR TITLE
Update Remote Playback API demo for compatibility with WebKit

### DIFF
--- a/media/remote-playback.html
+++ b/media/remote-playback.html
@@ -28,7 +28,7 @@
     <input id="togglePreload" type="checkbox" checked/>
     <label for="togglePreload">Video Preload</label>
     <video id="video" controls playsinline
-           src="https://storage.googleapis.com/media-session/caminandes/short.mp4#t=113"
+           src="https://storage.googleapis.com/media-session/caminandes/short.mp4"
            poster="https://storage.googleapis.com/media-session/caminandes/artwork-512.png"
     ></video>
     <p>
@@ -107,7 +107,8 @@
       };
       
       function updateRemoteStateWebKit() {
-        log('webkitCurrentPlaybackTargetIsWireless = ' + video.webkitCurrentPlaybackTargetIsWireless);
+        log('webkitCurrentPlaybackTargetIsWireless = ' +
+           video.webkitCurrentPlaybackTargetIsWireless);
         if (!video.webkitCurrentPlaybackTargetIsWireless) {
           // Let's watch remote device availability when there's no connected
           // remote device.

--- a/media/remote-playback.html
+++ b/media/remote-playback.html
@@ -64,6 +64,10 @@
           log('Disconnected from the remote device.');
           updateRemoteState();
         });
+      } else if (video.webkitShowPlaybackTargetPicker) {
+        updateRemoteStateWebKit();
+        video.addEventListener(‘webkitcurrentplaybacktargetiswirelesschanged',
+          function(e) { updateRemoteStateWebKit(); });
       } else {
         log.textContent += 'The Remote Playback API is not supported yet.';
         promptButton.disabled = true;
@@ -98,19 +102,47 @@
         }
       };
 
+      function onWebKitPlaybackTargetAvailabilityChanged(e) {
+        handleAvailabilityChange(e.availability);
+      };
+      
+      function updateRemoteStateWebKit() {
+        log('webkitCurrentPlaybackTargetIsWireless = ' + video.webkitCurrentPlaybackTargetIsWireless);
+        if (!video.webkitCurrentPlaybackTargetIsWireless) {
+          // Let's watch remote device availability when there's no connected
+          // remote device.
+          log('Starting watching remote device availability...');
+          video.addEventListener('webkitplaybacktargetavailabilitychanged',
+              onWebKitPlaybackTargetAvailabilityChanged);
+        } else {
+          // If remote device is connecting or connected, we should stop
+          // watching remote device availability to save power.
+          log('Stopping watching remote device availability...');
+          video.removeEventListener('webkitplaybacktargetavailabilitychanged',
+              onWebKitPlaybackTargetAvailabilityChanged);
+        }
+      };
+      
       function handleAvailabilityChange(availability) {
         log('Remote device ' + (availability ? 'available' : 'not available'));
       };
 
       promptButton.addEventListener('click', function() {
         log('Prompt button clicked');
-        video.remote.prompt()
-        .catch(error => {
-          log('Argh! ' + error)
-        });
+        if (video.remote) {
+          video.remote.prompt().catch(error => {
+             log('Argh! ' + error)
+          });
+        } else if (video.webkitShowPlaybackTargetPicker) {
+          video.webkitShowPlaybackTargetPicker();
+        }
       });
 
       toggleRemotePlayback.addEventListener('click', function() {
+        if (video['disableRemotePlayback'] === undefined) {
+          log('Toggling remote playback is not supported');
+          return;
+        }
         if (video.disableRemotePlayback) {
           video.disableRemotePlayback = null;
           log('Video remote playback is enabled');

--- a/media/remote-playback.html
+++ b/media/remote-playback.html
@@ -66,8 +66,8 @@
         });
       } else if (video.webkitShowPlaybackTargetPicker) {
         updateRemoteStateWebKit();
-        video.addEventListener(‘webkitcurrentplaybacktargetiswirelesschanged',
-          function(e) { updateRemoteStateWebKit(); });
+        video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged',
+            function(e) { updateRemoteStateWebKit(); });
       } else {
         log.textContent += 'The Remote Playback API is not supported yet.';
         promptButton.disabled = true;


### PR DESCRIPTION
This updates the Remote Playback API demo for compatibility with the currently shipped WebKit API:

https://developer.apple.com/documentation/webkitjs/adding_an_airplay_button_to_your_safari_media_controls

This is mostly to understand the current behavior of the API.  If you don't want to include WebKit support in this demo, I can put it in a separate file or keep it in my repo.

I also changed the video timestamp to start at the beginning since there are only about 20 seconds left otherwise.

CC @mounirlamouri