### PR TITLE
Avoid blink effect

### DIFF
--- a/media-recorder/mustache.html
+++ b/media-recorder/mustache.html
@@ -180,6 +180,16 @@ async function draw() {
       (canvas.width - video.videoWidth * ratio) / 2, 0,
       video.videoWidth * ratio, video.videoHeight * ratio);  
 
+  if (!isDetectingFaces) {
+    // Detect faces.
+    console.count('Detecting faces');
+    isDetectingFaces = true;
+    faceDetector.detect(canvas).then(facesArray => {
+      faces = facesArray;
+      isDetectingFaces = false;    
+    });    
+  }
+  
   // Draw mustache and hat on previously detected face.
   if (faces.length) {
     const face = faces[0].boundingBox;
@@ -209,16 +219,6 @@ async function draw() {
           mustache.height * face.width / 2 / mustache.width);
     }
   }
-
-  if (isDetectingFaces) {
-    return;
-  }
-
-  // Detect faces.
-  console.count('Detecting faces');
-  isDetectingFaces = true;
-  faces = await faceDetector.detect(canvas);
-  isDetectingFaces = false;
 }
 
 function startRecording() {


### PR DESCRIPTION
Two corrections : 
1. Forcing the detection on the canvas with just the video => we are shure that the detection will be trigger each times.
2. Using the result with a promise instead of async await enshure us that we draw the easter egg at each draw (event if a detection is trigger)